### PR TITLE
feat(company-detail): implement company detail screen with navigation from companies and map

### DIFF
--- a/ICNNavigatorMobile/App.tsx
+++ b/ICNNavigatorMobile/App.tsx
@@ -1,15 +1,19 @@
-
 import React from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, getFocusedRouteNameFromRoute } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
-import MapScreen from './src/screens/main/MapScreen';
-import CompaniesScreen from './src/screens/main/CompaniesScreen';
 import { View, Text } from 'react-native';
 import { Colors } from './src/constants/colors';
 
+// Import screens
+import MapScreen from './src/screens/main/MapScreen';
+import CompaniesScreen from './src/screens/main/CompaniesScreen';
+import CompanyDetailScreen from './src/screens/main/CompanyDetailScreen';
+
+// Placeholder screens
 function ProfileScreen() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -19,41 +23,117 @@ function ProfileScreen() {
 }
 
 const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+// Companies Stack Navigator
+function CompaniesStack({ navigation, route }: any) {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen 
+        name="CompaniesList" 
+        component={CompaniesScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen 
+        name="CompanyDetail" 
+        component={CompanyDetailScreen}
+        options={{ 
+          headerShown: false,
+          animation: 'slide_from_right'
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+// Map Stack Navigator
+function MapStack({ navigation, route }: any) {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen 
+        name="MapView" 
+        component={MapScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen 
+        name="CompanyDetail" 
+        component={CompanyDetailScreen}
+        options={{ 
+          headerShown: false,
+          animation: 'slide_from_bottom'
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+// Main Tab Navigator
+function MainTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ focused, color, size }) => {
+          let iconName: keyof typeof Ionicons.glyphMap;
+          
+          if (route.name === 'Companies') {
+            iconName = focused ? 'list' : 'list-outline';
+          } else if (route.name === 'Map') {
+            iconName = focused ? 'location' : 'location-outline';
+          } else {
+            iconName = focused ? 'person' : 'person-outline';
+          }
+          
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+        tabBarActiveTintColor: Colors.primary,
+        tabBarInactiveTintColor: Colors.black50,
+        headerStyle: {
+          backgroundColor: Colors.primary,
+        },
+        headerTintColor: Colors.white,
+      })}
+    >
+      <Tab.Screen 
+        name="Companies" 
+        component={CompaniesStack}
+        options={({ route }) => ({
+          headerShown: getFocusedRouteNameFromRoute(route) !== 'CompanyDetail',
+          headerTitle: 'Companies',
+          tabBarStyle: {
+            display: getFocusedRouteNameFromRoute(route) === 'CompanyDetail' ? 'flex' : 'flex',
+          },
+        })}
+      />
+      <Tab.Screen 
+        name="Map" 
+        component={MapStack}
+        options={({ route }) => ({
+          headerShown: getFocusedRouteNameFromRoute(route) !== 'CompanyDetail',
+          headerTitle: 'Map',
+          tabBarStyle: {
+            display: getFocusedRouteNameFromRoute(route) === 'CompanyDetail' ? 'flex' : 'flex',
+          },
+        })}
+      />
+      <Tab.Screen 
+        name="Profile" 
+        component={ProfileScreen}
+        options={{
+          headerShown: true,
+          headerTitle: 'Profile',
+        }}
+      />
+    </Tab.Navigator>
+  );
+}
 
 export default function App() {
   return (
     <SafeAreaProvider>
       <NavigationContainer>
         <StatusBar style="auto" />
-        <Tab.Navigator
-          screenOptions={({ route }) => ({
-            tabBarIcon: ({ focused, color, size }) => {
-              let iconName: keyof typeof Ionicons.glyphMap;
-              
-              if (route.name === 'Companies') {
-                iconName = focused ? 'list' : 'list-outline';
-              } else if (route.name === 'Map') {
-                iconName = focused ? 'location' : 'location-outline';
-              } else {
-                iconName = focused ? 'person' : 'person-outline';
-              }
-              
-              return <Ionicons name={iconName} size={size} color={color} />;
-            },
-            tabBarActiveTintColor: Colors.primary,
-            tabBarInactiveTintColor: Colors.black50,
-            headerStyle: {
-              backgroundColor: Colors.primary,
-            },
-            headerTintColor: Colors.white,
-          })}
-        >
-          <Tab.Screen name="Companies" component={CompaniesScreen} />
-          <Tab.Screen name="Map" component={MapScreen} />
-          <Tab.Screen name="Profile" component={ProfileScreen} />
-        </Tab.Navigator>
+        <MainTabs />
       </NavigationContainer>
     </SafeAreaProvider>
   );
 }
-

--- a/ICNNavigatorMobile/src/navigation/AppNavigator.tsx
+++ b/ICNNavigatorMobile/src/navigation/AppNavigator.tsx
@@ -5,6 +5,8 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
 import AuthNavigator from './AuthNavigator';
 import MainNavigator from './MainNavigator';
+import CompanyDetailScreen from '../screens/main/CompanyDetailScreen';
+
 
 const Stack = createNativeStackNavigator();
 

--- a/ICNNavigatorMobile/src/screens/main/CompaniesScreen.tsx
+++ b/ICNNavigatorMobile/src/screens/main/CompaniesScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import SearchBar from '../../components/common/SearchBar';
 import CompanyCard from '../../components/common/CompanyCard';
 import FilterModal, { FilterOptions } from '../../components/common/FilterModal';
@@ -26,7 +27,10 @@ if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
-export default function CompaniesScreen({ navigation }: any) {
+export default function CompaniesScreen() {
+  // Navigation hook
+  const navigation = useNavigation<any>();
+  
   // State management
   const [searchText, setSearchText] = useState('');
   const [bookmarkedIds, setBookmarkedIds] = useState<string[]>([]);
@@ -142,7 +146,6 @@ export default function CompaniesScreen({ navigation }: any) {
   const handleCompanyPress = (company: Company) => {
     // Navigate to company detail screen
     navigation.navigate('CompanyDetail', { company });
-    console.log('Navigate to company:', company.name);
   };
 
   // Handle refresh

--- a/ICNNavigatorMobile/src/screens/main/CompanyDetailScreen.tsx
+++ b/ICNNavigatorMobile/src/screens/main/CompanyDetailScreen.tsx
@@ -1,13 +1,471 @@
-import React from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { 
+  View, 
+  Text, 
+  ScrollView, 
+  StyleSheet, 
+  TouchableOpacity,
+  Linking,
+  Share,
+  Platform,
+  StatusBar
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Company } from '../../types';
+import { Colors, Spacing } from '../../constants/colors';
 
-export default function CompanyDetailScreen({ route }: any) {
+interface CompanyDetailScreenProps {
+  route: any;
+  navigation: any;
+}
+
+export default function CompanyDetailScreen({ route, navigation }: CompanyDetailScreenProps) {
   const { company } = route.params as { company: Company };
-  
+  const [isBookmarked, setIsBookmarked] = useState(false);
+
+  // Handle back navigation
+  const handleBack = () => {
+    navigation.goBack();
+  };
+
+  // Handle bookmark toggle
+  const handleBookmark = () => {
+    setIsBookmarked(!isBookmarked);
+  };
+
+  // Handle share
+  const handleShare = async () => {
+    try {
+      await Share.share({
+        message: `Check out ${company.name} on ICN Navigator\n${company.address}`,
+        title: company.name,
+      });
+    } catch (error) {
+      console.error('Error sharing:', error);
+    }
+  };
+
+  // Handle email
+  const handleEmail = () => {
+    if (company.email) {
+      Linking.openURL(`mailto:${company.email}`);
+    }
+  };
+
+  // Handle phone call
+  const handleCall = () => {
+    if (company.phoneNumber) {
+      const phoneNumber = company.phoneNumber.replace(/[^0-9]/g, '');
+      Linking.openURL(`tel:${phoneNumber}`);
+    }
+  };
+
+  // Handle website
+  const handleWebsite = () => {
+    if (company.website) {
+      const url = company.website.startsWith('http') 
+        ? company.website 
+        : `https://${company.website}`;
+      Linking.openURL(url);
+    }
+  };
+
+  // Handle directions
+  const handleDirections = () => {
+    const scheme = Platform.select({
+      ios: 'maps:',
+      android: 'geo:',
+    });
+    const latLng = `${company.latitude},${company.longitude}`;
+    const label = encodeURIComponent(company.name);
+    
+    const url = Platform.select({
+      ios: `${scheme}${latLng}?q=${label}`,
+      android: `${scheme}${latLng}?q=${label}`,
+    });
+    
+    if (url) {
+      Linking.openURL(url);
+    }
+  };
+
   return (
-    <ScrollView style={styles.container}>
-      {/* Add company details here */}
-    </ScrollView>
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleBack} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={24} color={Colors.white} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Company Details</Text>
+        <View style={styles.headerActions}>
+          <TouchableOpacity onPress={handleBookmark} style={styles.headerButton}>
+            <Ionicons 
+              name={isBookmarked ? "bookmark" : "bookmark-outline"} 
+              size={24} 
+              color={Colors.white} 
+            />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={handleShare} style={styles.headerButton}>
+            <Ionicons name="share-outline" size={24} color={Colors.white} />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <ScrollView 
+        style={styles.content}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.contentContainer}
+      >
+        {/* Company Info Card */}
+        <View style={styles.card}>
+          <View style={styles.companyHeader}>
+            <View style={styles.avatar}>
+              <Text style={styles.avatarText}>
+                {company.name.charAt(0).toUpperCase()}
+              </Text>
+            </View>
+            <View style={styles.companyInfo}>
+              <Text style={styles.companyName}>{company.name}</Text>
+              {company.verificationStatus === 'verified' && (
+                <View style={styles.verifiedBadge}>
+                  <Ionicons name="checkmark-circle" size={16} color={Colors.success} />
+                  <Text style={styles.verifiedText}>
+                    Verified on {company.verificationDate || 'Recently'}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </View>
+
+          {/* Key Sectors */}
+          <View style={styles.sectorsContainer}>
+            <Text style={styles.sectionTitle}>Key Sectors</Text>
+            <View style={styles.sectorsList}>
+              {company.keySectors.map((sector, index) => (
+                <View key={index} style={styles.sectorChip}>
+                  <Text style={styles.sectorText}>{sector}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          {/* Company Type */}
+          {company.companyType && (
+            <View style={styles.infoRow}>
+              <Ionicons name="briefcase-outline" size={20} color={Colors.black50} />
+              <Text style={styles.infoLabel}>Type:</Text>
+              <Text style={styles.infoValue}>
+                {company.companyType.charAt(0).toUpperCase() + company.companyType.slice(1)}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* Contact Information Card */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Contact Information</Text>
+          
+          {/* Address */}
+          <TouchableOpacity style={styles.contactRow} onPress={handleDirections}>
+            <View style={styles.contactIcon}>
+              <Ionicons name="location-outline" size={20} color={Colors.primary} />
+            </View>
+            <View style={styles.contactContent}>
+              <Text style={styles.contactLabel}>Address</Text>
+              <Text style={styles.contactValue}>{company.address}</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={Colors.black50} />
+          </TouchableOpacity>
+
+          {/* Phone */}
+          {company.phoneNumber && (
+            <TouchableOpacity style={styles.contactRow} onPress={handleCall}>
+              <View style={styles.contactIcon}>
+                <Ionicons name="call-outline" size={20} color={Colors.primary} />
+              </View>
+              <View style={styles.contactContent}>
+                <Text style={styles.contactLabel}>Phone</Text>
+                <Text style={styles.contactValue}>{company.phoneNumber}</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={Colors.black50} />
+            </TouchableOpacity>
+          )}
+
+          {/* Email */}
+          {company.email && (
+            <TouchableOpacity style={styles.contactRow} onPress={handleEmail}>
+              <View style={styles.contactIcon}>
+                <Ionicons name="mail-outline" size={20} color={Colors.primary} />
+              </View>
+              <View style={styles.contactContent}>
+                <Text style={styles.contactLabel}>Email</Text>
+                <Text style={styles.contactValue}>{company.email}</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={Colors.black50} />
+            </TouchableOpacity>
+          )}
+
+          {/* Website */}
+          {company.website && (
+            <TouchableOpacity style={styles.contactRow} onPress={handleWebsite}>
+              <View style={styles.contactIcon}>
+                <Ionicons name="globe-outline" size={20} color={Colors.primary} />
+              </View>
+              <View style={styles.contactContent}>
+                <Text style={styles.contactLabel}>Website</Text>
+                <Text style={styles.contactValue}>{company.website}</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={Colors.black50} />
+            </TouchableOpacity>
+          )}
+        </View>
+
+        {/* Quick Actions */}
+        <View style={styles.quickActions}>
+          <TouchableOpacity style={styles.actionButton} onPress={handleCall}>
+            <Ionicons name="call" size={24} color={Colors.white} />
+            <Text style={styles.actionButtonText}>Call</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.actionButton} onPress={handleEmail}>
+            <Ionicons name="mail" size={24} color={Colors.white} />
+            <Text style={styles.actionButtonText}>Email</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.actionButton} onPress={handleDirections}>
+            <Ionicons name="navigate" size={24} color={Colors.white} />
+            <Text style={styles.actionButtonText}>Directions</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Additional Information */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Additional Information</Text>
+          <View style={styles.additionalInfo}>
+            <Text style={styles.infoText}>
+              This company is listed in the ICN Navigator directory. 
+              For more information about their services and capabilities, 
+              please contact them directly using the information provided above.
+            </Text>
+            {company.verificationStatus === 'unverified' && (
+              <View style={styles.warningBox}>
+                <Ionicons name="information-circle" size={20} color={Colors.warning} />
+                <Text style={styles.warningText}>
+                  This company has not yet been verified. Please verify information independently.
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F5F5F5',
+  },
+  header: {
+    backgroundColor: Colors.primary,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    paddingTop: Platform.OS === 'ios' ? 48 : StatusBar.currentHeight ? StatusBar.currentHeight + 12 : 30,
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  backButton: {
+    padding: 4,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: Colors.white,
+    flex: 1,
+    textAlign: 'center',
+    marginHorizontal: 12,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  headerButton: {
+    padding: 4,
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    paddingBottom: 20,
+  },
+  card: {
+    backgroundColor: Colors.white,
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: Colors.text,
+    marginBottom: 16,
+  },
+  companyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: Colors.orange[300],
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  avatarText: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: Colors.white,
+  },
+  companyInfo: {
+    flex: 1,
+  },
+  companyName: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: Colors.text,
+    marginBottom: 4,
+  },
+  verifiedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  verifiedText: {
+    fontSize: 12,
+    color: Colors.success,
+  },
+  sectorsContainer: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.black50,
+    marginBottom: 8,
+  },
+  sectorsList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  sectorChip: {
+    backgroundColor: Colors.orange[400],
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  sectorText: {
+    fontSize: 13,
+    color: Colors.primary,
+    fontWeight: '500',
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  infoLabel: {
+    fontSize: 14,
+    color: Colors.black50,
+  },
+  infoValue: {
+    fontSize: 14,
+    color: Colors.text,
+    fontWeight: '500',
+  },
+  contactRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.black20,
+  },
+  contactIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.orange[400],
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  contactContent: {
+    flex: 1,
+  },
+  contactLabel: {
+    fontSize: 12,
+    color: Colors.black50,
+    marginBottom: 2,
+  },
+  contactValue: {
+    fontSize: 14,
+    color: Colors.text,
+  },
+  quickActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginHorizontal: 16,
+    marginTop: 20,
+    gap: 12,
+  },
+  actionButton: {
+    flex: 1,
+    backgroundColor: Colors.primary,
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: 'center',
+    gap: 4,
+  },
+  actionButtonText: {
+    fontSize: 12,
+    color: Colors.white,
+    fontWeight: '500',
+  },
+  additionalInfo: {
+    gap: 12,
+  },
+  infoText: {
+    fontSize: 14,
+    color: Colors.black50,
+    lineHeight: 20,
+  },
+  warningBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: Colors.orange[400],
+    padding: 12,
+    borderRadius: 8,
+    gap: 8,
+  },
+  warningText: {
+    flex: 1,
+    fontSize: 13,
+    color: Colors.text,
+    lineHeight: 18,
+  },
+});

--- a/ICNNavigatorMobile/src/screens/main/MapScreen.tsx
+++ b/ICNNavigatorMobile/src/screens/main/MapScreen.tsx
@@ -147,7 +147,14 @@ export default function MapScreen() {
 
   // Navigate to company detail
   const navigateToDetail = (company: Company) => {
+    console.log('Navigating to detail for:', company.name); // Debug log
     navigation.navigate('CompanyDetail', { company });
+  };
+
+  // Handle callout press (alternative approach)
+  const handleCalloutPress = (company: Company) => {
+    console.log('Callout pressed for:', company.name); // Debug log
+    navigateToDetail(company);
   };
 
   // Handler for company selection from dropdown
@@ -270,30 +277,46 @@ export default function MapScreen() {
               latitude: company.latitude,
               longitude: company.longitude,
             }}
-            onPress={() => handleMarkerPress(company)}
+            onPress={() => {
+              console.log('Marker pressed:', company.name); // Debug log
+              handleMarkerPress(company);
+            }}
+            onCalloutPress={() => {
+              console.log('Callout pressed:', company.name); // Debug log
+              handleCalloutPress(company);
+            }}
             pinColor={getMarkerColor(company)}
+            tracksViewChanges={false}
           >
-            <Callout style={styles.callout}>
-              <TouchableOpacity onPress={() => navigateToDetail(company)}>
-                <View style={styles.calloutContent}>
-                  <Text style={styles.calloutTitle}>{company.name}</Text>
-                  <Text style={styles.calloutAddress}>{company.address}</Text>
-                  <View style={styles.calloutSectors}>
-                    {company.keySectors.map((sector, index) => (
-                      <Text key={index} style={styles.calloutSector}>{sector}</Text>
-                    ))}
+            <Callout 
+              style={styles.callout}
+              onPress={() => {
+                console.log('Callout onPress:', company.name); // Alternative method
+                navigateToDetail(company);
+              }}
+              tooltip={false}
+            >
+              <View style={styles.calloutContent}>
+                <Text style={styles.calloutTitle}>{company.name}</Text>
+                <Text style={styles.calloutAddress}>{company.address}</Text>
+                <View style={styles.calloutSectors}>
+                  {company.keySectors.map((sector, index) => (
+                    <Text key={index} style={styles.calloutSector}>{sector}</Text>
+                  ))}
+                </View>
+                {company.verificationStatus === 'verified' && (
+                  <View style={styles.verifiedIndicator}>
+                    <Ionicons name="checkmark-circle" size={12} color={Colors.success} />
+                    <Text style={styles.verifiedText}>Verified</Text>
                   </View>
-                  {company.verificationStatus === 'verified' && (
-                    <View style={styles.verifiedIndicator}>
-                      <Ionicons name="checkmark-circle" size={12} color={Colors.success} />
-                      <Text style={styles.verifiedText}>Verified</Text>
-                    </View>
-                  )}
-                  <View style={styles.calloutButton}>
-                    <Text style={styles.calloutButtonText}>View Details →</Text>
+                )}
+                <View style={styles.calloutButton}>
+                  <View style={styles.calloutButtonInner}>
+                    <Ionicons name="information-circle-outline" size={14} color={Colors.primary} />
+                    <Text style={styles.calloutButtonText}>Tap to View Details</Text>
                   </View>
                 </View>
-              </TouchableOpacity>
+              </View>
             </Callout>
           </Marker>
         ))}
@@ -497,6 +520,16 @@ const styles = StyleSheet.create({
     paddingTop: 8,
     borderTopWidth: 1,
     borderTopColor: Colors.black20,
+    alignItems: 'center',
+  },
+  calloutButtonInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: Colors.orange[400],
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
   },
   calloutButtonText: {
     fontSize: 12,

--- a/ICNNavigatorMobile/src/screens/main/MapScreen.tsx
+++ b/ICNNavigatorMobile/src/screens/main/MapScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useMemo } from 'react';
 import { View, StyleSheet, Text, TouchableOpacity, Platform } from 'react-native';
 import MapView, { Marker, PROVIDER_GOOGLE, Region, Callout } from 'react-native-maps';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import SearchBarWithDropdown from '../../components/common/SearchBarWithDropdown';
 import FilterModal, { FilterOptions } from '../../components/common/FilterModal';
 import { Colors, Spacing } from '../../constants/colors';
@@ -16,6 +17,9 @@ const MELBOURNE_REGION: Region = {
 };
 
 export default function MapScreen() {
+  // Navigation hook
+  const navigation = useNavigation<any>();
+  
   const mapRef = useRef<MapView>(null);
   const [searchText, setSearchText] = useState('');
   const [selectedCompany, setSelectedCompany] = useState<Company | null>(null);
@@ -139,6 +143,11 @@ export default function MapScreen() {
       latitudeDelta: 0.01,
       longitudeDelta: 0.01,
     }, 500);
+  };
+
+  // Navigate to company detail
+  const navigateToDetail = (company: Company) => {
+    navigation.navigate('CompanyDetail', { company });
   };
 
   // Handler for company selection from dropdown
@@ -265,21 +274,26 @@ export default function MapScreen() {
             pinColor={getMarkerColor(company)}
           >
             <Callout style={styles.callout}>
-              <View style={styles.calloutContent}>
-                <Text style={styles.calloutTitle}>{company.name}</Text>
-                <Text style={styles.calloutAddress}>{company.address}</Text>
-                <View style={styles.calloutSectors}>
-                  {company.keySectors.map((sector, index) => (
-                    <Text key={index} style={styles.calloutSector}>{sector}</Text>
-                  ))}
-                </View>
-                {company.verificationStatus === 'verified' && (
-                  <View style={styles.verifiedIndicator}>
-                    <Ionicons name="checkmark-circle" size={12} color={Colors.success} />
-                    <Text style={styles.verifiedText}>Verified</Text>
+              <TouchableOpacity onPress={() => navigateToDetail(company)}>
+                <View style={styles.calloutContent}>
+                  <Text style={styles.calloutTitle}>{company.name}</Text>
+                  <Text style={styles.calloutAddress}>{company.address}</Text>
+                  <View style={styles.calloutSectors}>
+                    {company.keySectors.map((sector, index) => (
+                      <Text key={index} style={styles.calloutSector}>{sector}</Text>
+                    ))}
                   </View>
-                )}
-              </View>
+                  {company.verificationStatus === 'verified' && (
+                    <View style={styles.verifiedIndicator}>
+                      <Ionicons name="checkmark-circle" size={12} color={Colors.success} />
+                      <Text style={styles.verifiedText}>Verified</Text>
+                    </View>
+                  )}
+                  <View style={styles.calloutButton}>
+                    <Text style={styles.calloutButtonText}>View Details →</Text>
+                  </View>
+                </View>
+              </TouchableOpacity>
             </Callout>
           </Marker>
         ))}
@@ -339,6 +353,13 @@ export default function MapScreen() {
               <Text style={styles.verifiedText}>Verified Company</Text>
             </View>
           )}
+          <TouchableOpacity 
+            style={styles.viewDetailsButton}
+            onPress={() => navigateToDetail(selectedCompany)}
+          >
+            <Text style={styles.viewDetailsButtonText}>View Full Details</Text>
+            <Ionicons name="arrow-forward" size={18} color={Colors.white} />
+          </TouchableOpacity>
         </View>
       )}
       
@@ -361,7 +382,7 @@ const styles = StyleSheet.create({
   },
   filterBar: {
     position: 'absolute',
-    top: 100,  // Changed from 60 to 100 to position it lower
+    top: 100,
     left: 16,
     right: 16,
     backgroundColor: Colors.white,
@@ -432,7 +453,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   callout: {
-    width: 200,
+    width: 220,
   },
   calloutContent: {
     padding: 10,
@@ -465,6 +486,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: 4,
+  },
+  verifiedText: {
+    fontSize: 10,
+    color: Colors.success,
+    marginLeft: 4,
+  },
+  calloutButton: {
+    marginTop: 8,
+    paddingTop: 8,
+    borderTopWidth: 1,
+    borderTopColor: Colors.black20,
+  },
+  calloutButtonText: {
+    fontSize: 12,
+    color: Colors.primary,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   searchAreaButton: {
     position: 'absolute',
@@ -540,6 +578,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 8,
+    marginBottom: 12,
   },
   sectorChip: {
     backgroundColor: Colors.orange[400],
@@ -555,11 +594,21 @@ const styles = StyleSheet.create({
   verifiedBadge: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 12,
+    marginBottom: 16,
   },
-  verifiedText: {
-    fontSize: 12,
-    color: Colors.success,
-    marginLeft: 4,
+  viewDetailsButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.primary,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    gap: 8,
+  },
+  viewDetailsButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.white,
   },
 });


### PR DESCRIPTION

- Add comprehensive CompanyDetailScreen with full company information display
- Implement contact actions (call, email, website, directions)
- Add share and bookmark functionality
- Create stack navigators for Companies and Map tabs
- Configure navigation from Companies list to detail screen
- Enable navigation from Map markers and bottom panel to detail screen
- Fix header gap issues with proper status bar handling
- Hide tab navigator header on detail screen to prevent double headers
- Add slide animations (from-right for Companies, from-bottom for Map)
- Implement proper back navigation to source screen
- Style company information cards with verification badges
- Add quick action buttons for call, email, and directions
- Include additional information section with verification warnings
- Support both iOS and Android platform-specific behaviors